### PR TITLE
Fix submodule weirdness

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "Modules/IntelliTect.PSDropbin"]
 	path = Modules/IntelliTect.PSDropbin
 	url = https://github.com/IntelliTect/PSDropbin.git
+[submodule ".\\Modules\\IntelliTect.PSDropbin"]
+	path = .\\Modules\\IntelliTect.PSDropbin
+	url = https://github.com/IntelliTect/PSDropbin.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "Modules/IntelliTect.PSDropbin"]
 	path = Modules/IntelliTect.PSDropbin
 	url = https://github.com/IntelliTect/PSDropbin.git
-[submodule ".\\Modules\\IntelliTect.PSDropbin"]
-	path = .\\Modules\\IntelliTect.PSDropbin
-	url = https://github.com/IntelliTect/PSDropbin.git


### PR DESCRIPTION
The PSDropbin submodule was pointed at a commit that was never pushed to the remote, so it would give an error like this when cloning:

error: Server does not allow request for unadvertised object {5c81fd}
Fetched in submodule path 'Modules/IntelliTect.PSDropbin', but it did not contain {5c81fd}. Direct fetching of that commit failed.