### PR TITLE
Enhance Join-Path to support an unlimited number of parameters

### DIFF
--- a/Modules.Tests/Common.Tests.ps1
+++ b/Modules.Tests/Common.Tests.ps1
@@ -6,6 +6,28 @@ Import-Module -Name $PSScriptRoot\..\Modules\IntelliTect.Common -Force
 
 #EndHeader#>
 
+Describe 'Join-Path' {
+    try {
+        # Set directory to use FileSystem PSProvider
+        $originalPath = Get-Location
+        Set-Location $env:HOMEDRIVE
+        It '1 parameters' {
+            Join-Path 'test' | Should Be 'test'
+        }
+        It '2 parameters' {
+            Join-Path 'c:' 'test' | Should Be (Microsoft.PowerShell.Management\Join-Path 'c:' 'test')
+        }
+        It '3 parameters' {
+            IntelliTect.Common\Join-Path 'c:' 'test1' 'test2' | `
+                Should Be (Microsoft.PowerShell.Management\Join-Path  'c:' (Microsoft.PowerShell.Management\Join-Path  'test1' 'test2'))
+        }
+    }
+    finally {
+        Set-Location $originalPath
+    }
+}
+
+
 Function Script:Get-SampleDisposeObject {
     $object = New-Object object
     $object | Add-Member -MemberType NoteProperty -Name DisposeCalled -Value $false

--- a/Modules.Tests/File.Tests.ps1
+++ b/Modules.Tests/File.Tests.ps1
@@ -188,3 +188,16 @@ Describe 'Remove-FileToRecycleBin' {
         Write-Warning 'Remove-FileToRecycleBin is not currently supported on this platform.'
     }
 }
+
+Describe 'Join-Path' {
+    It 'Provide valid paramaters' {
+        Join-Path 'first' 'second' | Should Be ([string]::Join([System.IO.Path]::DirectorySeparatorChar, 'first', 'second' ))
+        Join-Path 'first' 'second' 'third' | Should Be ([string]::Join([System.IO.Path]::DirectorySeparatorChar, 'first', 'second', 'third' ))
+        #Value on pipeline passing not yet supported.
+        #'first','second','third' | Join-Path | Should Be ([string]::Join([System.IO.Path]::DirectorySeparatorChar, 'first', 'second', 'third' ))
+    }
+    try {
+        Microsoft.PowerShell.Management\Join-Path 'first' 'second' 'third' -ErrorAction ignore
+        Write-Warning 'Microsoft.PowerShell.Management\Join-Path has built in support for multiple parameters.' 
+    } catch [System.Management.Automation.ParameterBindingException] { <# Ignore #>}
+}

--- a/Modules/IntelliTect.Common/IntelliTect.Common.psm1
+++ b/Modules/IntelliTect.Common/IntelliTect.Common.psm1
@@ -1,5 +1,11 @@
 
 if((Get-Command Join-Path).Version -lt '6.0') {
+# An alternative approach is to trap the error but this causes a code analysis warning that can't be 
+# turned of with a block.
+# try {
+#     Microsoft.PowerShell.Management\Join-Path 'first' 'second' 'third' -ErrorAction ignore
+# }
+# catch [System.Management.Automation.ParameterBindingException] {
     Function Join-Path {
         switch ($args.Count) {
             0 { Join-Path @args }
@@ -13,7 +19,7 @@ if((Get-Command Join-Path).Version -lt '6.0') {
                 Write-Output $result
              }
         }
-    } 
+    }
 }
 
 

--- a/Modules/IntelliTect.Common/IntelliTect.Common.psm1
+++ b/Modules/IntelliTect.Common/IntelliTect.Common.psm1
@@ -1,4 +1,21 @@
 
+if((Get-Command Join-Path).Version -lt '6.0') {
+    Function Join-Path {
+        switch ($args.Count) {
+            0 { Join-Path @args }
+            1 { $args[0] | Write-Output }
+            2 { Microsoft.PowerShell.Management\Join-Path @args }
+            default {
+                $result = $args[0]
+                $args | Select-Object -Skip 1 | ForEach-Object{
+                    $result = Join-Path $result $_
+                }
+                Write-Output $result
+             }
+        }
+    } 
+}
+
 
 Function Add-PathToEnvironmentVariable {
     [CmdletBinding(SupportsShouldProcess)]
@@ -99,9 +116,10 @@ Function Highlight([string]$pattern, [Int32]$Context = 10, [Parameter(ValueFromP
 }
 set-alias HL highlight
 
-function New-Array {
-    [CmdletBinding()][OutputType('System.Array')]
-    $args
+function Initialize-Array {
+    [CmdletBinding()]
+    [OutputType('System.Array')]
+    [System.Array]$args | Write-Output
 }
 
 Function Add-DisposeScript {

--- a/Modules/IntelliTect.File/IntelliTect.File.psm1
+++ b/Modules/IntelliTect.File/IntelliTect.File.psm1
@@ -325,7 +325,44 @@ Function Remove-FileSystemItemForcibly {
     }
 }
 }
- 
+
+# Only create this function if it isn't build into the framework.
+try {
+    Microsoft.PowerShell.Management\Join-Path 'first' 'second' 'third' -ErrorAction ignore
+} 
+catch [System.Management.Automation.ParameterBindingException] { 
+    <#
+    .SYNOPSIS
+        Provide a wrapper to `Microsoft.PowerShell.Management\Join-Path` that can take an unlimited number of parameters.
+    .DESCRIPTION
+        `Microsoft.PowerShell.Management\Join-Path` only allows two parameters. This implementation of Join-Path
+        wraps `Microsoft.PowerShell.Management\Join-Path` and supports n parameters.
+    .EXAMPLE
+        PS C:\> Join-Path c:\first second third
+        c:\first\second\third
+        
+    .INPUTS
+        None
+    .OUTPUTS
+        string
+    .NOTES
+        None
+    #>
+    Function Join-Path {
+        [CmdletBinding()]
+        [OutputType([string])]
+        param (
+            [Parameter(Mandatory)][string]$BeginPath,
+            [Parameter(Mandatory,ValueFromRemainingArguments)][string[]]$ChildPathLet
+        )
+        
+        #TODO: Add support for ValueFromPipeline
+
+        $pathSuffix=$BeginPath
+        @($ChildPathLet) | ForEach-Object{ $pathSuffix = Microsoft.PowerShell.Management\Join-Path $pathSuffix $_}
+        Write-Output $pathSuffix
+    }
+}
 
 # TODO: Add functions below
 # See https://github.com/MarkMichaelis/Private/blob/InitialMachineSetup/Install-Dropbox.ps1 for


### PR DESCRIPTION
`'Microsoft.PowerShell.Management\Join-Path` only supports two parameters. Provide a wrapper `Join-Path` function that can take an unlimited number of parameters.