### PR TITLE
Various renaming and minor improvements in IntelliTect.GitUndo git

### DIFF
--- a/Modules.Tests/Common.Tests.ps1
+++ b/Modules.Tests/Common.Tests.ps1
@@ -91,6 +91,20 @@ Describe "Register-AutoDispose" {
 }
 
 Describe "Get-Tempdirectory" {
+    It 'Verify error handling when the directory is in use.' {
+        $tempItem = $null
+        try {
+            $tempItem = Get-TempDirectory
+            push-location $tempItem
+            { $tempItem.Dispose()} | Should Throw
+        }
+        finally {
+            if (Test-Path $tempItem) {
+                Pop-Location
+                Remove-Item $tempItem -Force -Recurse
+            }
+        }
+    }
     It 'Verify the temp directory created is in the %TEMP% (temporary) directory' {
         try {
             $tempItem = Get-TempDirectory
@@ -101,7 +115,6 @@ Describe "Get-Tempdirectory" {
             Test-Path $tempItem | Should Be $false
         }
     }
-
 }
 
 Describe "Get-TempDirectory/Get-TempFile" {

--- a/Modules.Tests/Common.Tests.ps1
+++ b/Modules.Tests/Common.Tests.ps1
@@ -91,20 +91,6 @@ Describe "Register-AutoDispose" {
 }
 
 Describe "Get-Tempdirectory" {
-    It 'Verify error handling when the directory is in use.' {
-        $tempItem = $null
-        try {
-            $tempItem = Get-TempDirectory
-            push-location $tempItem
-            { $tempItem.Dispose()} | Should Throw
-        }
-        finally {
-            if (Test-Path $tempItem) {
-                Pop-Location
-                Remove-Item $tempItem -Force -Recurse
-            }
-        }
-    }
     It 'Verify the temp directory created is in the %TEMP% (temporary) directory' {
         try {
             $tempItem = Get-TempDirectory
@@ -147,20 +133,6 @@ Describe "Get-TempDirectory/Get-TempFile" {
                 }
             }
         }
-    It 'Verify that the Dispose method removes the directory even if it contains files.' {
-        $tempItem = $null
-        try {
-            $tempItem = Get-TempDirectory
-            Get-TempFile -Path $tempItem
-            $tempItem.Dispose()
-            Test-Path $tempItem | Should Be $false
-        }
-        finally {
-            if(Test-Path $tempItem) {
-                Remove-Item $tempItem -Force -Recurse
-            }
-        }
-    }
 }
 
 Describe "Get-TempFile" {

--- a/Modules.Tests/Common.Tests.ps1
+++ b/Modules.Tests/Common.Tests.ps1
@@ -101,6 +101,7 @@ Describe "Get-Tempdirectory" {
             Test-Path $tempItem | Should Be $false
         }
     }
+
 }
 
 Describe "Get-TempDirectory/Get-TempFile" {
@@ -133,6 +134,20 @@ Describe "Get-TempDirectory/Get-TempFile" {
                 }
             }
         }
+    It 'Verify that the Dispose method removes the directory even if it contains files.' {
+        $tempItem = $null
+        try {
+            $tempItem = Get-TempDirectory
+            Get-TempFile -Path $tempItem
+            $tempItem.Dispose()
+            Test-Path $tempItem | Should Be $false
+        }
+        finally {
+            if(Test-Path $tempItem) {
+                Remove-Item $tempItem -Force -Recurse
+            }
+        }
+    }
 }
 
 Describe "Get-TempFile" {

--- a/Modules.Tests/Common.Tests.ps1
+++ b/Modules.Tests/Common.Tests.ps1
@@ -91,20 +91,6 @@ Describe "Register-AutoDispose" {
 }
 
 Describe "Get-Tempdirectory" {
-    It 'Verify error handling when the directory is in use.' {
-        $tempItem = $null
-        try {
-            $tempItem = Get-TempDirectory
-            push-location $tempItem
-            { $tempItem.Dispose()} | Should Throw
-        }
-        finally {
-            if (Test-Path $tempItem) {
-                Pop-Location
-                Remove-Item $tempItem -Force -Recurse
-            }
-        }
-    }
     It 'Verify the temp directory created is in the %TEMP% (temporary) directory' {
         try {
             $tempItem = Get-TempDirectory
@@ -137,30 +123,16 @@ Describe "Get-TempDirectory/Get-TempFile" {
     }
     ($tempDirectory = Get-TempDirectory) |
         Register-AutoDispose -ScriptBlock {
-        $path = $tempDirectory.FullName
-        # Now that a temporary directory exists, call Get-TempDirectory and Get-TempFile
-        # and specify the above directory in which to place the temp directory/file.
-        (Get-TempDirectory -Path $path), (Get-TempFile $path) | ForEach-Object {
-            It "Verify item is created with the correct path" {
-                Register-AutoDispose $_ {}
-                Test-Path $_ | Should Be $false
+            $path = $tempDirectory.FullName
+            # Now that a temporary directory exists, call Get-TempDirectory and Get-TempFile
+            # and specify the above directory in which to place the temp directory/file.
+            (Get-TempDirectory -Path $path), (Get-TempFile $path) | ForEach-Object {
+                It "Verify item is created with the correct path" {
+                    Register-AutoDispose $_ {}
+                    Test-Path $_ | Should Be $false
+                }
             }
         }
-    }
-    It 'Verify that the Dispose method removes the directory even if it contains files.' {
-        $tempItem = $null
-        try {
-            $tempItem = Get-TempDirectory
-            Get-TempFile -Path $tempItem
-            $tempItem.Dispose()
-            Test-Path $tempItem | Should Be $false
-        }
-        finally {
-            if (Test-Path $tempItem) {
-                Remove-Item $tempItem -Force -Recurse
-            }
-        }
-    }
 }
 
 Describe "Get-TempFile" {

--- a/Modules/IntelliTect.Common/IntelliTect.Common.psm1
+++ b/Modules/IntelliTect.Common/IntelliTect.Common.psm1
@@ -254,9 +254,14 @@ Function Script:Get-FileSystemTempItem {
                 $file = New-Item $_ -ItemType $ItemType -ErrorAction Stop
 
                 $file | Add-DisposeScript -DisposeScript {
+<<<<<<< HEAD
                     Remove-Item $this.FullName -Force -Recurse -ErrorVariable failed # Recurse is allowed on both files and directoriese
                     if($failed) { throw $failed }
                 }
+=======
+                    Remove-Item $this.FullName -Force -Recurse } # Recurse is allowed on both files and directories
+
+>>>>>>> Added support for Get-TempDirectory to correctly dispose (remove) the directory even if it contains items.
                 Write-Output $file
 
             }

--- a/Modules/IntelliTect.Common/IntelliTect.Common.psm1
+++ b/Modules/IntelliTect.Common/IntelliTect.Common.psm1
@@ -254,14 +254,9 @@ Function Script:Get-FileSystemTempItem {
                 $file = New-Item $_ -ItemType $ItemType -ErrorAction Stop
 
                 $file | Add-DisposeScript -DisposeScript {
-<<<<<<< HEAD
                     Remove-Item $this.FullName -Force -Recurse -ErrorVariable failed # Recurse is allowed on both files and directoriese
                     if($failed) { throw $failed }
                 }
-=======
-                    Remove-Item $this.FullName -Force -Recurse } # Recurse is allowed on both files and directories
-
->>>>>>> Added support for Get-TempDirectory to correctly dispose (remove) the directory even if it contains items.
                 Write-Output $file
 
             }

--- a/Modules/IntelliTect.Common/IntelliTect.Common.psm1
+++ b/Modules/IntelliTect.Common/IntelliTect.Common.psm1
@@ -254,9 +254,8 @@ Function Script:Get-FileSystemTempItem {
                 $file = New-Item $_ -ItemType $ItemType -ErrorAction Stop
 
                 $file | Add-DisposeScript -DisposeScript {
-                    Remove-Item $this.FullName -Force -Recurse -ErrorVariable failed # Recurse is allowed on both files and directoriese
-                    if($failed) { throw $failed }
-                }
+                    Remove-Item $this.FullName -Force -Recurse } # Recurse is allowed on both files and directories
+
                 Write-Output $file
 
             }

--- a/Modules/IntelliTect.Git/IntelliTect.Git.psm1
+++ b/Modules/IntelliTect.Git/IntelliTect.Git.psm1
@@ -27,7 +27,7 @@ Function Invoke-GitCommand {
     param(
         [Parameter(Mandatory)][string]$ActionMessage
         ,[Parameter(Mandatory,ValueFromRemainingArguments)][string[]]$Command
-        #,[Parameter(ParameterSetName='OutputAsObject')][string[]]$GitProperty
+        ,[Parameter(ParameterSetName='OutputAsObject')][string[]]$GitProperty
         ,[Parameter(ParameterSetName='OutputAsText')][string]$Format = $null
     )
     DynamicParam {


### PR DESCRIPTION
Changed Invoke-GitCommand to use Invoke-Command with a scriptblock rather than a Invoke-Expression with a string.
Rename Get-GitStatusObject to Get-GitItemStatus
Rename Get-GitObjectProperty to Get-GitItemProperty
Renamed Get-GitItemStatus 'path' parameter to 'Filter'