### PR TITLE
Removed the Join-Path fucntion

### DIFF
--- a/Modules.Tests/Common.Tests.ps1
+++ b/Modules.Tests/Common.Tests.ps1
@@ -5,35 +5,6 @@ Get-Module IntelliTect.Common | Remove-Module -Force
 Import-Module -Name $PSScriptRoot\..\Modules\IntelliTect.Common\IntelliTect.Common.psm1 -Force
 <#EndHeader#>
 
-Describe 'Join-Path' {
-    try {
-        # Set directory to use FileSystem PSProvider
-        $originalPath = Get-Location
-        Set-Location $env:HOMEDRIVE
-        It '0 parameters' {
-            Join-Path | Should Be ''
-        }
-        It '1 parameters' {
-            Join-Path 'test' | Should Be 'test'
-        }
-        It '2 parameters' {
-            Join-Path 'c:' 'test' | Should Be (Microsoft.PowerShell.Management\Join-Path 'c:' 'test')
-        }
-        It '3 parameters' {
-            IntelliTect.Common\Join-Path 'c:' 'test1' 'test2' | `
-                Should Be (Microsoft.PowerShell.Management\Join-Path  'c:' (Microsoft.PowerShell.Management\Join-Path  'test1' 'test2'))
-        }
-        It '4 parameters' {
-            IntelliTect.Common\Join-Path 'c:' 'test1' 'test2' 'test3' | `
-                Should Be (Microsoft.PowerShell.Management\Join-Path  'c:' (Microsoft.PowerShell.Management\Join-Path  'test1' (Microsoft.PowerShell.Management\Join-Path  'test2' 'test3')))
-        }
-
-    }
-    finally {
-        Set-Location $originalPath
-    }
-}
-
 Function Script:Get-SampleDisposeObject {
     $object = New-Object object
     $object | Add-Member -MemberType NoteProperty -Name DisposeCalled -Value $false

--- a/Modules/IntelliTect.Common/IntelliTect.Common.psm1
+++ b/Modules/IntelliTect.Common/IntelliTect.Common.psm1
@@ -1,31 +1,4 @@
 
-if((Get-Command Join-Path).Version -lt '6.0') {
-# An alternative approach is to trap the error but this causes a code analysis warning that can't be 
-# turned of with a block.
-# try {
-#     Microsoft.PowerShell.Management\Join-Path 'first' 'second' 'third' -ErrorAction ignore
-# }
-# catch [System.Management.Automation.ParameterBindingException] {
-    Function Join-Path {
-        @($args) | ForEach-Object{ if($_ -eq $null) {throw 'Join-Path parameter cannot be null.'} }
-        switch ($args.Count) {
-            0 { Write-Output '' }
-            1 { $args[0] | Write-Output }
-            2 { Microsoft.PowerShell.Management\Join-Path $args[0] $args[1] }
-            default {
-                $result = $args[0]
-                if($result -eq $null) { throw 'InvalidOperationException: The $result parameter should not be null.'} 
-                $args | Select-Object -Skip 1 | ForEach-Object{
-                    if($_ -eq $null) { throw 'InvalidOperationException: The pipepline parameter should not be null.'}
-                    $result = Join-Path $result $_
-                }
-                Write-Output $result
-            }
-        }
-    }
-}
-
-
 Function Add-PathToEnvironmentVariable {
     [CmdletBinding(SupportsShouldProcess)]
     param(


### PR DESCRIPTION
It was buggy, caused code analysis warnings, and is no longer relevant with PowerShell 6.0 or later